### PR TITLE
[BUGFIX] Fix duplicate t_cls_name check in class_factory.py

### DIFF
--- a/dependency/core/lib/common/class_factory.py
+++ b/dependency/core/lib/common/class_factory.py
@@ -67,7 +67,7 @@ class ClassFactory(object):
             if type_name not in cls.__registry__:
                 cls.__registry__[type_name] = {t_cls_name: t_cls}
             else:
-                if t_cls_name in cls.__registry__:
+                if t_cls_name in cls.__registry__[type_name]:
                     raise ValueError("Cannot register duplicate class ({})".format(t_cls_name))
                 cls.__registry__[type_name].update({t_cls_name: t_cls})
             return t_cls
@@ -87,7 +87,7 @@ class ClassFactory(object):
         if type_name not in cls.__registry__:
             cls.__registry__[type_name] = {t_cls_name: t_cls}
         else:
-            if t_cls_name in cls.__registry__:
+            if t_cls_name in cls.__registry__[type_name]:
                 raise ValueError(
                     "Cannot register duplicate class ({})".format(t_cls_name))
             cls.__registry__[type_name].update({t_cls_name: t_cls})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/dayu-autostreamer/dayu/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
Bug fix
<!--
Add one of the following kinds:
bug
cleanup
documentation
enhancement
test

-->


**What this PR does / why we need it**:
- Fixes the duplicate class check logic in `class_factory.register()` and `class_factory.register_cls()`
- Previously, the check searched the entire registry, which could lead to false negatives
- Now correctly checks only within the specified `type_name` registry

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```