### PR TITLE
ci: update GitHub Actions workflow configurations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+  push:
+    branches: [ main ]
   schedule:
     # Weekly on Sundays.
     - cron: '20 1 * * 0'
@@ -45,7 +47,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3.28.17
+      uses: github/codeql-action/init@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.29.5
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -65,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3.28.17
+      uses: github/codeql-action/analyze@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.29.5

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -6,6 +6,8 @@ on:
     - cron: '20 1 * * 6'
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +42,6 @@ jobs:
           results_format: sarif
           publish_results: true
           exclude_checks: "Pinned-Dependencies"
-          exclude_paths: "vendor/**"
 
       - name: "Upload artifact"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Update CodeQL action from v3.28.17 to v3.29.5 with SHA pinning
- Add push trigger on main branch to CodeQL workflow
- Add pull_request trigger to SonarCloud workflow
- Remove vendor path exclusion from SonarCloud workflow

These updates enhance security by pinning action versions to specific SHAs and improve CI coverage by ensuring workflows run on both push and pull request events.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/dayu-autostreamer/dayu/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
bug
cleanup
documentation
enhancement
test

-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```